### PR TITLE
Server: add option to specify https+basicauth option for git clone

### DIFF
--- a/server/src/services/command.service.ts
+++ b/server/src/services/command.service.ts
@@ -200,6 +200,8 @@ export class CommandService {
           )}.git ${serviceFolder}`;
         } else if (attributes.gitCheckoutType === 'https') {
           repoUrl = `https://${serviceToClone.gitUrl}`;
+        } else if (attributes.gitCheckoutType === 'https+basicauth') {
+          repoUrl = `https://${attributes.basicAuth}@${serviceToClone.gitUrl}`;
         } else {
           throw new Error('Unknown gitCheckoutType :( ');
         }


### PR DESCRIPTION
This can be useful for cloning repositories where the user doesn't have SSH key, but has access tokens