### PR TITLE
Server: report `cloned` as true only if more than 1 file is present

### DIFF
--- a/server/src/services/services.service.ts
+++ b/server/src/services/services.service.ts
@@ -243,7 +243,7 @@ export class ServicesService {
 
   serviceIsCloned(service: BaseService) {
     const cwd = this.getServicePath(service.name);
-    return fs.existsSync(cwd) && fs.readdirSync(cwd).length;
+    return fs.existsSync(cwd) && fs.readdirSync(cwd).length > 1;
   }
 
   serviceHasBranch(service: BaseService) {


### PR DESCRIPTION
While cloning, git repository only contains `.git` directory, after a successful clone, the directory contains all repository files.